### PR TITLE
Changes google client id to a placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,6 @@ Run the following commands from this directory to fetch dependencies and compile
 ```
 $ yarn
 $ gulp
+$ find ./build -type f -exec sed -i "s/GOOGLE_OAUTH_CLIENT_ID/the-actual-client-id/g" {} \; # on GNU/Linux
+$ find ./build -type f -exec sed -i '' -e "s/GOOGLE_OAUTH_CLIENT_ID/the-actual-client-id/g" {} \; # on MacOS
 ```

--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="google-signin-client_id"
-          content="184853849394-v89e96desio4dub3360vg32p1l4r3jqd.apps.googleusercontent.com">
+          content="GOOGLE_OAUTH_CLIENT_ID">
 
     <title>OpenDC</title>
 

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@
 
     <!-- Google Sign-in -->
     <meta name="google-signin-client_id"
-          content="184853849394-v89e96desio4dub3360vg32p1l4r3jqd.apps.googleusercontent.com">
+          content="GOOGLE_OAUTH_CLIENT_ID">
 
     <!-- Set viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">

--- a/src/profile.html
+++ b/src/profile.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="google-signin-client_id"
-          content="184853849394-v89e96desio4dub3360vg32p1l4r3jqd.apps.googleusercontent.com">
+          content="GOOGLE_OAUTH_CLIENT_ID">
 
     <title>OpenDC - Profile</title>
 

--- a/src/projects.html
+++ b/src/projects.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="google-signin-client_id"
-          content="184853849394-v89e96desio4dub3360vg32p1l4r3jqd.apps.googleusercontent.com">
+          content="GOOGLE_OAUTH_CLIENT_ID">
 
     <title>OpenDC - Projects</title>
 


### PR DESCRIPTION
While deploying, you may need to use a shell script to change the placeholder to an actual client id. The command to do that would be something like `find ./opendc-frontend/build -type f -exec sed -i "s/GOOGLE_OAUTH_CLIENT_ID/$OAUTH_CLIENT_ID/g" {} \;`