### PR TITLE
Integrate OAUTH client ID injection in build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,7 @@ Run the following commands from this directory to fetch dependencies and compile
 
 ```
 $ yarn
-$ gulp
+$ gulp --config=config.json
 ```
+
+**Note:** You need to replace `config.json` with the name / path of a real config file. This config file can be created by making a copy of the `sample_config.json` template and replacing the entries with your setup data. Make sure not to check this new config file into the VCS, as it is unique to each deployment situation.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,14 @@
+/**
+ * Build file for the frontend codebase of OpenDC.
+ *
+ * Usage:
+ *  $ gulp config.json        # for a single build
+ *  $ gulp watch config.json  # to run once, watch for changes, and rebuild when something changed
+ */
+
 'use strict';
 
+const runSequence = require('run-sequence');
 const gulp = require('gulp');
 const notify = require('gulp-notify');
 const source = require('vinyl-source-stream');
@@ -15,7 +24,7 @@ const bower = require('gulp-bower');
 
 
 /**
- * STYLES
+ * Stylesheet task.
  */
 const stylesRootDir = './src/styles/';
 const stylesDestDir = './build/styles/';
@@ -34,7 +43,7 @@ gulp.task('styles', function () {
 
 
 /**
- * SCRIPTS
+ * Script task.
  */
 const scriptsRootDir = './src/scripts/';
 const scriptsDestDir = './build/scripts/';
@@ -59,7 +68,7 @@ gulp.task('scripts', function () {
 
 
 /**
- * TYPESCRIPT DEFINITIONS
+ * TypeScript definitions.
  */
 gulp.task("typings", function () {
     return gulp.src("./typings.json")
@@ -69,7 +78,7 @@ gulp.task("typings", function () {
 
 
 /**
- * HTML
+ * HTML task.
  */
 const htmlRootDir = './src/';
 const htmlDestDir = './build/';
@@ -88,7 +97,7 @@ gulp.task('html', function () {
 
 
 /**
- * IMAGES
+ * Images task.
  */
 const imagesRootDir = './src/img/';
 const imagesDestDir = './build/img/';
@@ -103,7 +112,7 @@ gulp.task('images', function () {
 
 
 /**
- * CLEAN
+ * Clean task.
  */
 gulp.task('clean', function () {
     return del(['./build']);
@@ -111,7 +120,7 @@ gulp.task('clean', function () {
 
 
 /**
- * BOWER
+ * Bower task.
  */
 gulp.task('bower', function () {
     return bower({cmd: 'install'}, ['--allow-root'])
@@ -120,15 +129,15 @@ gulp.task('bower', function () {
 
 
 /**
- * DEFAULT TASK
+ * Default build task.
  */
-gulp.task('default', ['clean', 'typings'], function () {
-    gulp.start('styles', 'bower', 'scripts', 'html', 'images');
+gulp.task('default', function () {
+    runSequence('clean', 'typings', 'styles', 'bower', 'scripts', 'html', 'images');
 });
 
 
 /**
- * WATCH
+ * Watch task.
  */
 gulp.task('watch', ['default'], function () {
     gulp.watch(stylesRootDir + '**/*.less', ['styles']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,16 +34,23 @@ const bower = require('gulp-bower');
  * @returns {Object} the config file contents.
  */
 function getConfigFile() {
-    const configFilePath = argv.config;
+    const configInput = argv.config;
 
-    if (configFilePath === undefined) {
-        gulpUtil.log(gulpUtil.colors.red('Config file argument missing\n'), "Usage:\n" +
-            " $ gulp --config=config.json");
+    if (configInput === undefined) {
+        gulpUtil.log(gulpUtil.colors.red('Config file argument missing\n'), 'Usage:\n' +
+            ' $ gulp --config=config.json');
         throw new Exception();
     }
 
     try {
-        return require('./' + configFilePath);
+        let configFilePath;
+        if (configInput.indexOf('/') === -1) {
+            configFilePath = './' + configInput;
+        } else {
+            configFilePath = configInput;
+        }
+
+        return require(configFilePath);
     } catch (error) {
         gulpUtil.log(gulpUtil.colors.red('Config file could not be read'), error);
         throw new Exception();
@@ -83,7 +90,7 @@ const scriptsFilePaths = scriptsFileNames.map(function (fileName) {
 });
 
 gulp.task('scripts', function () {
-    var tasks = scriptsFilePaths.map(function (entry, index) {
+    const tasks = scriptsFilePaths.map(function (entry, index) {
         return browserify({entries: [entry]})
             .plugin(tsify, {insertGlobals: true})
             .bundle()

--- a/package.json
+++ b/package.json
@@ -20,17 +20,20 @@
     "gulp-notify": "^2.2.0",
     "gulp-processhtml": "^1.1.0",
     "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.5.4",
     "gulp-typings": "^2.0.4",
     "jquery": "^3.1.0",
     "jquery-mousewheel": "^3.1.13",
     "jquery.easing": "^1.4.1",
     "less": "^2.7.1",
+    "run-sequence": "^1.2.2",
     "socket.io-client": "^1.4.8",
     "tsify": "^2.0.2",
     "tslint": "^3.10.2",
     "typescript": "^2.1.4",
     "typings": "^1.3.2",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "yargs": "^6.6.0"
   },
   "devDependencies": {
     "jasmine-core": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-typings": "^2.0.4",
+    "gulp-util": "^3.0.8",
     "jquery": "^3.1.0",
     "jquery-mousewheel": "^3.1.13",
     "jquery.easing": "^1.4.1",

--- a/sample_config.json
+++ b/sample_config.json
@@ -1,0 +1,3 @@
+{
+  "GOOGLE_OAUTH_CLIENT_ID": "the-google-oauth-client-id"
+}

--- a/src/app.html
+++ b/src/app.html
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="google-signin-client_id"
-          content="184853849394-v89e96desio4dub3360vg32p1l4r3jqd.apps.googleusercontent.com">
+    <meta name="google-signin-client_id" content="GOOGLE_OAUTH_CLIENT_ID">
 
     <title>OpenDC</title>
 

--- a/src/index.html
+++ b/src/index.html
@@ -19,8 +19,7 @@
     <meta property="og:locale" content="en_US">
 
     <!-- Google Sign-in -->
-    <meta name="google-signin-client_id"
-          content="184853849394-v89e96desio4dub3360vg32p1l4r3jqd.apps.googleusercontent.com">
+    <meta name="google-signin-client_id" content="GOOGLE_OAUTH_CLIENT_ID">
 
     <!-- Set viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">

--- a/src/profile.html
+++ b/src/profile.html
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="google-signin-client_id"
-          content="184853849394-v89e96desio4dub3360vg32p1l4r3jqd.apps.googleusercontent.com">
+    <meta name="google-signin-client_id" content="GOOGLE_OAUTH_CLIENT_ID">
 
     <title>OpenDC - Profile</title>
 

--- a/src/projects.html
+++ b/src/projects.html
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="google-signin-client_id"
-          content="184853849394-v89e96desio4dub3360vg32p1l4r3jqd.apps.googleusercontent.com">
+    <meta name="google-signin-client_id" content="GOOGLE_OAUTH_CLIENT_ID">
 
     <title>OpenDC - Projects</title>
 


### PR DESCRIPTION
This PR adds a command-line option to the `gulp` build process to properly setup the Google OAuth client ID of each deployment. A sample config file is included, to be used as a template.