### PR TITLE
Fix button handler being triggered multiple times

### DIFF
--- a/src/scripts/controllers/simulationcontroller.ts
+++ b/src/scripts/controllers/simulationcontroller.ts
@@ -297,7 +297,11 @@ export class SimulationController {
             });
         });
 
-        $("#new-experiment-btn").click(() => {
+        let newExperimentBtn = $("#new-experiment-btn");
+        // Remove previously added event handlers
+        newExperimentBtn.off();
+
+        newExperimentBtn.click(() => {
             const nameInput = $("#new-experiment-name-input");
             if (nameInput.val() === "") {
                 $(".experiment-name-alert").show();


### PR DESCRIPTION
The issue was that previous event handlers of the same button were not removed on closing the dialog. This is now resolved by removing all event handlers of the 'new experiment' button when registering a new handler.