### PR TITLE
Fixes for bugs in experiment simulation

### DIFF
--- a/src/scripts/controllers/simulation/chart.ts
+++ b/src/scripts/controllers/simulation/chart.ts
@@ -92,7 +92,7 @@ export class ChartController {
         return c3.generate({
             bindto: chartId,
             data: {
-                xFormat: '%S',
+                // xFormat: '%S',
                 x: "time",
                 columns: this.chartData,
                 names: this.names
@@ -141,7 +141,7 @@ export class ChartController {
     }
 
     public update(): void {
-        this.xSeries = (<(number|string)[]>["time"]).concat(Util.range(this.simulationController.currentTick));
+        this.xSeries = (<(number|string)[]>["time"]).concat(<any[]> Util.timeRange(this.simulationController.currentTick));
 
         this.chartData = [this.xSeries];
 

--- a/src/scripts/util.ts
+++ b/src/scripts/util.ts
@@ -599,4 +599,15 @@ export class Util {
             return i.toString();
         })
     }
+
+    /**
+     * Returns an array containing all numbers of a range from 0 to x (including x).
+     */
+    public static timeRange(x: number): Date[] {
+        return Util.range(x).map((tick: number) => {
+            const t = new Date(1970, 0, 1); // Epoch
+            t.setSeconds(tick);
+            return t;
+        });
+    }
 }

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -993,6 +993,12 @@ a:hover {
     font-weight: bold;
   }
 
+  .list-body {
+    max-height: 200px;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
   .experiment-row {
     background: #f8f8f8;
     border: 1px solid #b6b6b6;
@@ -1074,7 +1080,7 @@ a:hover {
 
   .window-body {
     width: 100%;
-    height: 340px;
+    height: 500px;
 
     padding: 10px;
 


### PR DESCRIPTION
This PR provides two bugfixes:

* The experiment list in the experiment window no longer flows over the edge of the window
* The charting window now can handle timestamps with second counts above 100 (was not possible previously, due to an error in the date-parsing functionality of the charting library)