### PR TITLE
Fix bug concerning click on time marker

### DIFF
--- a/src/components/app/timeline/Timeline.sass
+++ b/src/components/app/timeline/Timeline.sass
@@ -99,6 +99,8 @@ $timeline-border: $border-width solid $gray-semi-dark
 
       z-index: 503
 
+      pointer-events: none
+
     .section-marker
       position: absolute
       top: 0


### PR DESCRIPTION
When clicked directly, the time marker would jump to tick 0, which is undesirable.

Fixes #39