### PR TITLE
Disable rack construction when leaving room

### DIFF
--- a/src/reducers/construction-mode.js
+++ b/src/reducers/construction-mode.js
@@ -1,14 +1,12 @@
-import { combineReducers } from "redux";
-import { OPEN_EXPERIMENT_SUCCEEDED } from "../actions/experiments";
+import {combineReducers} from "redux";
+import {OPEN_EXPERIMENT_SUCCEEDED} from "../actions/experiments";
+import {GO_DOWN_ONE_INTERACTION_LEVEL} from "../actions/interaction-level";
 import {
   CANCEL_NEW_ROOM_CONSTRUCTION_SUCCEEDED,
   FINISH_NEW_ROOM_CONSTRUCTION,
   START_NEW_ROOM_CONSTRUCTION_SUCCEEDED
 } from "../actions/topology/building";
-import {
-  START_RACK_CONSTRUCTION,
-  STOP_RACK_CONSTRUCTION
-} from "../actions/topology/room";
+import {START_RACK_CONSTRUCTION, STOP_RACK_CONSTRUCTION} from "../actions/topology/room";
 
 export function currentRoomInConstruction(state = -1, action) {
   switch (action.type) {
@@ -29,6 +27,7 @@ export function inRackConstructionMode(state = false, action) {
       return true;
     case STOP_RACK_CONSTRUCTION:
     case OPEN_EXPERIMENT_SUCCEEDED:
+    case GO_DOWN_ONE_INTERACTION_LEVEL:
       return false;
     default:
       return state;


### PR DESCRIPTION
This PR ensures that rack construction is disabled when the user leaves the room without disabling rack construction mode first.

Fixes #47