### PR TITLE
Add label to current tick line in state charts

### DIFF
--- a/src/components/app/sidebars/elements/LoadChartComponent.js
+++ b/src/components/app/sidebars/elements/LoadChartComponent.js
@@ -4,6 +4,7 @@ import SvgSaver from "svgsaver";
 import {
   VictoryAxis,
   VictoryChart,
+  VictoryLabel,
   VictoryLine,
   VictoryScatter
 } from "victory";
@@ -56,9 +57,17 @@ const VictoryChartComponent = ({ data, currentTick, showCurrentTick }) => (
     <VictoryScatter data={data} />
     {showCurrentTick ? (
       <VictoryLine
+        labelComponent={
+          <VictoryLabel renderInPortal angle={90} dy={-5} dx={60} />
+        }
         data={[{ x: currentTick + 1, y: 0 }, { x: currentTick + 1, y: 1 }]}
+        labels={point =>
+          point.y === 1
+            ? "Current tick : " + convertSecondsToFormattedTime(currentTick)
+            : ""}
         style={{
-          data: { stroke: "#00A6D6", strokeWidth: 3 }
+          data: { stroke: "#00A6D6", strokeWidth: 4 },
+          labels: { fill: "#00A6D6" }
         }}
       />
     ) : (


### PR DESCRIPTION
This vertically-oriented label gives the user an indication of what that blue bar actually means in the graph, for the case that this was not clear from the UI itself.

![image](https://user-images.githubusercontent.com/5272244/32395556-e48907e0-c0e1-11e7-91f5-3c4f3e51ddbc.png)

Fixes #31